### PR TITLE
Handle synchronous return of socket.ReceiveFromAsync()

### DIFF
--- a/src/DTLS.Net/Server.cs
+++ b/src/DTLS.Net/Server.cs
@@ -406,7 +406,12 @@ namespace DTLS
                         remoteEndPoint = new IPEndPoint(IPAddress.IPv6Any, 0);
                     e.RemoteEndPoint = remoteEndPoint;
                     e.SetBuffer(0, 4096);
-                    socket.ReceiveFromAsync(e);
+                    bool pending = socket.ReceiveFromAsync(e);
+                    if (!pending)
+                    {
+                        // If ReceiveFromAsync returns false, the callback will not be triggered automatically so we must call it ourselves.
+                        ReceiveCallback(sender, e);
+                    }
                 }
             }
 		}


### PR DESCRIPTION
If data is already pending when socket.ReceiveFromAsync() is called,
the return value will be set to false. When this happens, the
System.Net.Sockets.SocketAsyncEventArgs.Completed event will **not** be
triggered, so we must call it ourselves.

If we fail to call the Completed event ourselves, the DTLS server
will stop responding to any incoming data, indefinitely.